### PR TITLE
Remove unused btrfs dependency

### DIFF
--- a/classes/trustmeinstaller.bbclass
+++ b/classes/trustmeinstaller.bbclass
@@ -261,10 +261,8 @@ IMAGE_CMD_trustmeinstaller () {
 	dd if=/dev/zero of="$trustme_datafs" conv=notrunc,fsync iflag=sync oflag=sync bs=${INSTALLER_TARGET_ALIGN} count=$datapart_size_targetblocks
 	/bin/sync
 	bbdebug 1 "Creating ext4 fs of size ${datapart_size_targetblocks} blocks, ${datapart_size_bytes} bytes on file $trustme_datafs"
-	#mkfs.btrfs --byte-count "${datapart_size_bytes}" --label trustme --rootdir "$tmp_datapart" "$trustme_datafs"
 	mkfs.ext4 -b ${INSTALLER_TARGET_ALIGN} -d "$tmp_datapart" -L trustmeinstaller "$trustme_datafs" "${datapart_size_targetblocks}"
 	chmod 644 "$trustme_datafs"
-	#btrfsck "$trustme_datafs"
 
 	/bin/sync
 

--- a/classes/trustmekeytool.bbclass
+++ b/classes/trustmekeytool.bbclass
@@ -22,7 +22,6 @@ do_image_trustmekeytool[depends] = " \
     parted-native:do_populate_sysroot \
     mtools-native:do_populate_sysroot \
     dosfstools-native:do_populate_sysroot \
-    btrfs-tools-native:do_populate_sysroot \
     gptfdisk-native:do_populate_sysroot \
     pki-native:do_populate_sysroot \
 "

--- a/images/trustx-installer-initramfs.bb
+++ b/images/trustx-installer-initramfs.bb
@@ -22,7 +22,6 @@ PACKAGE_INSTALL = "\
 	e2fsprogs-resize2fs \
 	e2fsprogs-mke2fs \
 	e2fsprogs-e2fsck \
-	btrfs-tools \
 	kvmtool \
 	${ROOTFS_BOOTSTRAP_INSTALL} \
 	installer-boot \


### PR DESCRIPTION
btrfs is not used in installer-image anymore, so the dependency should be removed 