### PR TITLE
images/trustx-installer-initramfs: Remove libselinux

### DIFF
--- a/images/trustx-installer-initramfs.bb
+++ b/images/trustx-installer-initramfs.bb
@@ -7,7 +7,6 @@ PACKAGE_INSTALL = "\
 	base-passwd \
 	shadow \
 	mingetty \
-	libselinux \
 	cmld \
 	service-static \
 	control \


### PR DESCRIPTION
Recently, the meta-selinux layer was removed that is used anymore.
Currently, the build of the installer image fails for this reason.
This commit therefore removes the libselinux package from installer image.